### PR TITLE
Suppress clippy::non_send_fields_in_send_ty lint in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Suppress `clippy::non_send_fields_in_send_ty` lint in generated code. ([#2](https://github.com/taiki-e/negative-impl/pull/2))
+
 ## [0.1.0] - 2021-03-27
 
 Initial release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,8 @@ fn expand(trait_: TraitInfo, mut impl_: ItemImpl) -> TokenStream2 {
             pub struct #wrapper_ident<'a, T #sized>(::core::marker::PhantomData<&'a ()>, T);
             #unsafety impl<T #sized> #full_path for #wrapper_ident<'_, T>
                 where T: #full_path {}
+            // This is false positive as we generate a trait implementation with a condition that will never be true.
+            #[allow(clippy::non_send_fields_in_send_ty)]
             #impl_
         };
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -31,6 +31,7 @@ pub mod basic {
     assert_not_impl!(Foo<()>: RefUnwindSafe);
 }
 
+// https://github.com/taiki-e/negative-impl#conditional-negative-impls
 pub mod conditional {
     use super::*;
 
@@ -43,13 +44,8 @@ pub mod conditional {
     #[negative_impl]
     impl<T> !Send for B<Vec<T>> where T: Copy {}
 
-    trait Trait {}
-
-    impl<T: Send> Trait for T {}
-
-    unsafe impl<T> Send for A<Result<T, T>> {}
-
-    unsafe impl<T> Send for B<Result<T, T>> {}
+    unsafe impl<T: Send> Send for A<Result<T, T>> {}
+    unsafe impl<T: Send> Send for B<Result<T, T>> {}
 
     assert_not_impl!(A<Option<()>>: Send);
     assert_impl!(A<Result<(), ()>>: Send);


### PR DESCRIPTION
This is false positive as we generate a trait implementation with a
condition that will never be true.